### PR TITLE
Fix root target container name

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -89,4 +89,4 @@ const Root = (
 
 registerServiceWorker(store);
 
-ReactDOM.render(Root, document.getElementById('root') as HTMLElement);
+ReactDOM.render(Root, document.getElementById('root-layout') as HTMLElement);


### PR DESCRIPTION
**Bug:**
I was trying to use this tool at https://mydraft.cc/ and ran into an error: 

`Uncaught Error: Minified React error #200; visit https://reactjs.org/docs/error-decoder.html?invariant=200 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`

After cloning it locally I found it was actually pretty straightforward: 

`Uncaught Error: Target container is not a DOM element.`

**Fix:**
Seeing as the element was renamed from `root` to `root-layout`  in the html [just a few days ago](https://github.com/mydraft-cc/ui/commit/b4cba0165b1e3c14353421151c32acc0495b4e34#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeR17) I assumed that was intentional and simply changed the target name in the typescript to match it.

I can confirm that with this change the page now renders correctly for me locally. It looks great and I'm excited to use it, thank you for your hard work! If there is some more preferable solution to this, or you'd like me to add a test for this in some way, then please let me know or feel free to close this.