### PR TITLE
Add requirement for webpack-dev-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "webpack": "5.65.0",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.1",
-        "webpack-dev-server": "4.7.2",
+        "webpack-dev-server": "^4.7.2",
         "workbox-webpack-plugin": "^6.4.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack": "5.65.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.1",
-    "webpack-dev-server": "4.7.2",
+    "webpack-dev-server": "^4.7.2",
     "workbox-webpack-plugin": "^6.4.2"
   }
 }


### PR DESCRIPTION
When trying to run the code locally, I was running into this error:

```
$ npm start

> mydraft.cc@1.0.0 start
> webpack serve --config config/webpack.config.js --port 3002 --hot --server-type https --server-options-pfx dev/squidex-dev.pfx --server-options-passphrase password

[webpack-cli] Error: Unknown option '--server-type'
[webpack-cli] Run 'webpack --help' to see available commands and options
```

I just added the dependency for `webpack-dev-server` and that appears to have rectified the problem.