### PR TITLE
Make keyboard shortcuts work for Mac users using command key

### DIFF
--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -75,7 +75,7 @@ export const texts = {
         unsaved: '(unsaved)',
         visual: 'Visual',
         width: 'Width',
-        zoomIn: 'Zoom IN',
+        zoomIn: 'Zoom In',
         zoomOut: 'Zoom Out',
     },
 };

--- a/src/wireframes/components/actions/Components.tsx
+++ b/src/wireframes/components/actions/Components.tsx
@@ -27,11 +27,7 @@ export const ActionMenuButton = React.memo((props: ActionProps) => {
         return null;
     }
 
-    // Mac users expect to use the command key for shortcuts rather than the control key
-    const isMac = window.navigator.userAgent.indexOf('Mac') != -1;
-    const modKey = isMac ? 'COMMAND' : 'CTRL';
-
-    const title = shortcut ? `${tooltip} (${shortcut.replace('MOD', modKey)})` : tooltip;
+    const title = shortcut ? `${tooltip} (${shortcut.replace('MOD', modKeyFromUserAgent())})` : tooltip;
 
     return (
         <>
@@ -113,4 +109,11 @@ export const ActionMenuItem = React.memo((props: ActionProps) => {
             {label}
         </Menu.Item>
     );
+
 });
+
+function modKeyFromUserAgent(): string {
+    // Mac users expect to use the command key for shortcuts rather than the control key
+    const isMac = window.navigator.userAgent.indexOf('Mac') != -1;
+    return isMac ? 'COMMAND' : 'CTRL';
+}

--- a/src/wireframes/components/actions/Components.tsx
+++ b/src/wireframes/components/actions/Components.tsx
@@ -27,7 +27,11 @@ export const ActionMenuButton = React.memo((props: ActionProps) => {
         return null;
     }
 
-    const title = shortcut ? `${tooltip} (${shortcut})` : tooltip;
+    // Mac users expect to use the command key for shortcuts rather than the control key
+    const isMac = window.navigator.userAgent.indexOf('Mac') != -1;
+    const modKey = isMac ? 'COMMAND' : 'CTRL';
+
+    const title = shortcut ? `${tooltip} (${shortcut.replace('MOD', modKey)})` : tooltip;
 
     return (
         <>

--- a/src/wireframes/components/actions/use-clipboard.ts
+++ b/src/wireframes/components/actions/use-clipboard.ts
@@ -57,7 +57,7 @@ export function useClipboard() {
         disabled: !canCopy,
         icon: 'icon-copy',
         label: texts.common.copy,
-        shortcut: 'CTRL + C',
+        shortcut: 'MOD + C',
         tooltip: texts.common.copyTooltip,
         onAction: doCopy,
     }), [canCopy, doCopy]);
@@ -66,7 +66,7 @@ export function useClipboard() {
         disabled: !canCopy,
         icon: 'icon-cut',
         label: texts.common.cut,
-        shortcut: 'CTRL + X',
+        shortcut: 'MOD + X',
         tooltip: texts.common.cutTooltip,
         onAction: doCut,
     }), [canCopy, doCut]);
@@ -75,7 +75,7 @@ export function useClipboard() {
         disabled: !clipboard,
         icon: 'icon-paste',
         label: texts.common.paste,
-        shortcut: 'CTRL + V',
+        shortcut: 'MOD + V',
         tooltip: texts.common.pasteTooltip,
         onAction: doPaste,
     }), [clipboard, doPaste]);

--- a/src/wireframes/components/actions/use-grouping.ts
+++ b/src/wireframes/components/actions/use-grouping.ts
@@ -36,7 +36,7 @@ export function useGrouping() {
         disabled: !canGroup,
         icon: 'icon-group',
         label: texts.common.group,
-        shortcut: 'CTRL + G',
+        shortcut: 'MOD + G',
         tooltip: texts.common.groupTooltip,
         onAction: doGroup,
     }), [canGroup, doGroup]);
@@ -45,7 +45,7 @@ export function useGrouping() {
         disabled: !canUngroup,
         icon: 'icon-ungroup',
         label: texts.common.ungroup,
-        shortcut: 'CTRL + SHIFT + G',
+        shortcut: 'MOD + SHIFT + G',
         tooltip: texts.common.ungroupTooltip,
         onAction: doUngroup,
     }), [canUngroup, doUngroup]);

--- a/src/wireframes/components/actions/use-history.ts
+++ b/src/wireframes/components/actions/use-history.ts
@@ -28,7 +28,7 @@ export function useHistory() {
         disabled: !canRedo,
         icon: 'icon-redo',
         label: texts.common.redo,
-        shortcut: 'CTRL + Y',
+        shortcut: 'MOD + Y',
         tooltip: texts.common.redo,
         onAction: doRedo,
     }), [canRedo, doRedo]);
@@ -37,7 +37,7 @@ export function useHistory() {
         disabled: !canUndo,
         icon: 'icon-undo',
         label: texts.common.undo,
-        shortcut: 'CTRL + Z',
+        shortcut: 'MOD + Z',
         tooltip: texts.common.undo,
         onAction: doUndo,
     }), [canUndo, doUndo]);

--- a/src/wireframes/components/actions/use-loading.ts
+++ b/src/wireframes/components/actions/use-loading.ts
@@ -37,7 +37,7 @@ export function useLoading() {
         disabled: false,
         icon: 'icon-new',
         label: texts.common.newDiagram,
-        shortcut: 'CTRL + N',
+        shortcut: 'MOD + N',
         tooltip: texts.common.newDiagramTooltip,
         onAction: doNew,
     }), [doNew]);
@@ -46,7 +46,7 @@ export function useLoading() {
         disabled: !canSave,
         icon: 'icon-save',
         label: texts.common.saveDiagramTooltip,
-        shortcut: 'CTRL + S',
+        shortcut: 'MOD + S',
         tooltip: texts.common.saveDiagramTooltip,
         onAction: doSave,
     }), [doSave, canSave]);

--- a/src/wireframes/components/actions/use-locking.tsx
+++ b/src/wireframes/components/actions/use-locking.tsx
@@ -38,7 +38,7 @@ export function useLocking() {
             disabled: !selectedItem,
             icon,
             label: texts.common.lock,
-            shortcut: 'CTRL + L',
+            shortcut: 'MOD + L',
             tooltip: texts.common.lockTooltip,
             onAction: doToggle,
         };

--- a/src/wireframes/components/actions/use-locking.tsx
+++ b/src/wireframes/components/actions/use-locking.tsx
@@ -39,7 +39,7 @@ export function useLocking() {
             icon,
             label: texts.common.lock,
             shortcut: 'CTRL + L',
-            tooltip: texts.common.removeTooltip,
+            tooltip: texts.common.lockTooltip,
             onAction: doToggle,
         };
     }, [selectedItem, doToggle]);

--- a/src/wireframes/components/menu/LoadingMenu.tsx
+++ b/src/wireframes/components/menu/LoadingMenu.tsx
@@ -13,7 +13,7 @@ import { Button, Modal } from 'antd';
 import * as React from 'react';
 import { ActionMenuButton, useLoading } from './../actions';
 
-const text = require('@app/legal.html').default;
+const text = require('@app/legal.html');
 
 export const LoadingMenu = React.memo(() => {
     const forLoading = useLoading();

--- a/src/wireframes/model/actions/loading.ts
+++ b/src/wireframes/model/actions/loading.ts
@@ -92,7 +92,7 @@ export function loadingMiddleware(): Middleware {
                 store.dispatch(push(action.payload.tokenToRead));
             }
 
-            store.dispatch(showInfoToast('Succeeded to load diagram.'));
+            store.dispatch(showInfoToast('Successfully loaded diagram.'));
         } else if (loadDiagramAsync.rejected.match(action)) {
             store.dispatch(showErrorToast('Failed to load diagram.'));
         } else if (saveDiagramAsync.fulfilled.match(action)) {

--- a/src/wireframes/shapes/README.md
+++ b/src/wireframes/shapes/README.md
@@ -1,0 +1,90 @@
+# How to write a custom shape?
+
+Writing custom shapes is relatively easy and can be best understood by having a look to an existing implementation.
+
+## Terms
+
+Before we start we need to clarify a few terms:
+
+* **Appearance**: A list of properties, like colors and texts that define the appearance of a shape.
+* **Identifier**: A unique name for the shape type.
+* **Configurables**: A definition how custom appearance values should be displayed and edited in the right sidebar.
+* **Constraints**: Restrict the size calculation of the shape, e.g. the height of the label depends on the font size.
+* **Default Size**: The initial size when the shape is added to a diagram.
+
+## Steps
+
+When you create a new shape you have to execute the following steps:
+
+1. Create a new shape class.
+2. Create a copy of a shape image and rename it to the `{{identifier}}.png`.
+3. Add the shape class to the [index.ts](index.ts) file.
+4. Add the shape to a diagram and make a screenshot.
+5. Replace the image `{{identifier}}.png` with your screenshot.
+
+## Example
+
+The following example is a toggle button. The main responsibility of the shape is to render the SVG statements using an imperative approach. The render method is called whenever a change is changed. Then a diff process makes the necessary changes to update the SVG elements, to destroy them or to add new elements.
+
+```
+const STATE = 'STATE';
+const STATE_NORMAL = 'Normal';
+const STATE_CHECKED = 'Checked';
+
+const DEFAULT_APPEARANCE = {};
+DEFAULT_APPEARANCE[DefaultAppearance.FOREGROUND_COLOR] = 0x238b45;
+DEFAULT_APPEARANCE[DefaultAppearance.BACKGROUND_COLOR] = 0xbdbdbd;
+DEFAULT_APPEARANCE[DefaultAppearance.TEXT_DISABLED] = true;
+DEFAULT_APPEARANCE[DefaultAppearance.STROKE_COLOR] = 0xffffff;
+DEFAULT_APPEARANCE[DefaultAppearance.STROKE_THICKNESS] = 4;
+DEFAULT_APPEARANCE[STATE] = STATE_CHECKED;
+
+export class Toggle implements ShapePlugin {
+    public identifier(): string {
+        return 'Toggle';
+    }
+
+    public defaultAppearance() {
+        return DEFAULT_APPEARANCE;
+    }
+
+    public defaultSize() {
+        return { x: 60, y: 30 };
+    }
+
+    public configurables(factory: ConfigurableFactory) {
+        return [
+            factory.selection(STATE, 'State', [
+                STATE_NORMAL,
+                STATE_CHECKED,
+            ]),
+        ];
+    }
+
+    public render(ctx: RenderContext) {
+        const border = ctx.shape.strokeThickness;
+
+        const radius = Math.min(ctx.rect.width, ctx.rect.height) * 0.5;
+
+        const isUnchecked = ctx.shape.getAppearance(STATE) === STATE_NORMAL;
+
+        const circleY = ctx.rect.height * 0.5;
+        const circleX = isUnchecked ? radius : ctx.rect.width - radius;
+
+        const circleCenter = new Vec2(circleX, circleY);
+        const circleSize = radius - border;
+
+        const barColor = isUnchecked ? ctx.shape : ctx.shape.foregroundColor;
+
+        // Pill
+        ctx.renderer2.rectangle(0, radius, ctx.rect, p => {
+            p.setBackgroundColor(barColor);
+        });
+
+        // Circle.
+        ctx.renderer2.ellipse(0, Rect2.fromCenter(circleCenter, circleSize), p => {
+            p.setBackgroundColor(ctx.shape.strokeColor);
+        });
+    }
+}
+```


### PR DESCRIPTION
This PR addresses #110.

**14bfa3d0e52b33ca33232784da0aeb90a6cdc2cb**
As per [the resolution to this issue](https://github.com/ccampbell/mousetrap/issues/9) in the mousetrap library, we can use `MOD` to represent the "super" key regardless of the OS. Therefore, I have changed the shortcut keys to use `MOD` instead of `CTRL`, which now makes this work as expected on multiple operating systems.

**db9fec3624ef6e5effb477045f38067874191964**
The above change made the tooltip look a bit strange, since most people won't know what `MOD` means. Therefore, I check the user agent for the string `"Mac"` and change the tooltip message from `MOD` to `COMMAND` for Macintosh users and `CTRL` for others. Since `window.navigator.platform` is deprecated this is the best solution I could think of, but I'm happy to do this some other way if you have any suggestions!
