### PR TITLE
Lock/zoom in tooltip and load message fixes

### DIFF
--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -75,7 +75,7 @@ export const texts = {
         unsaved: '(unsaved)',
         visual: 'Visual',
         width: 'Width',
-        zoomIn: 'Zoom IN',
+        zoomIn: 'Zoom In',
         zoomOut: 'Zoom Out',
     },
 };

--- a/src/wireframes/components/actions/use-locking.tsx
+++ b/src/wireframes/components/actions/use-locking.tsx
@@ -39,7 +39,7 @@ export function useLocking() {
             icon,
             label: texts.common.lock,
             shortcut: 'CTRL + L',
-            tooltip: texts.common.removeTooltip,
+            tooltip: texts.common.lockTooltip,
             onAction: doToggle,
         };
     }, [selectedItem, doToggle]);

--- a/src/wireframes/model/actions/loading.ts
+++ b/src/wireframes/model/actions/loading.ts
@@ -92,7 +92,7 @@ export function loadingMiddleware(): Middleware {
                 store.dispatch(push(action.payload.tokenToRead));
             }
 
-            store.dispatch(showInfoToast('Succeeded to load diagram.'));
+            store.dispatch(showInfoToast('Successfully loaded diagram.'));
         } else if (loadDiagramAsync.rejected.match(action)) {
             store.dispatch(showErrorToast('Failed to load diagram.'));
         } else if (saveDiagramAsync.fulfilled.match(action)) {


### PR DESCRIPTION
Changed some of the messages in the app for correctness:

- The tooltip for the lock button previously used the delete tooltip language
- "Zoom IN" capitalization changed to "Zoom in"
- Minor grammatical change to load message 