### PR TITLE
Add configuration for padding in Rectangle

### DIFF
--- a/src/wireframes/shapes/neutral/rectangle.ts
+++ b/src/wireframes/shapes/neutral/rectangle.ts
@@ -54,7 +54,7 @@ export class Rectangle implements ShapePlugin {
     }
 
     private createText(ctx: RenderContext) {
-        ctx.renderer2.text(ctx.shape, ctx.rect.deflate(10), p => {
+        ctx.renderer2.text(ctx.shape, ctx.rect.deflate(10, 0), p => {
             p.setForegroundColor(ctx.shape);
         });
     }

--- a/src/wireframes/shapes/neutral/rectangle.ts
+++ b/src/wireframes/shapes/neutral/rectangle.ts
@@ -9,6 +9,8 @@ import { ConfigurableFactory, DefaultAppearance, RenderContext, ShapePlugin } fr
 import { CommonTheme } from './_theme';
 
 const BORDER_RADIUS = 'BORDER_RADIUS';
+const HORIZONTAL_PADDING = 'HORIZONTAL_PADDING';
+const VERTICAL_PADDING = 'VERTICAL_PADDING';
 
 const DEFAULT_APPEARANCE = {};
 DEFAULT_APPEARANCE[DefaultAppearance.FOREGROUND_COLOR] = 0;
@@ -19,6 +21,8 @@ DEFAULT_APPEARANCE[DefaultAppearance.FONT_SIZE] = CommonTheme.CONTROL_FONT_SIZE;
 DEFAULT_APPEARANCE[DefaultAppearance.STROKE_COLOR] = CommonTheme.CONTROL_BORDER_COLOR;
 DEFAULT_APPEARANCE[DefaultAppearance.STROKE_THICKNESS] = CommonTheme.CONTROL_BORDER_THICKNESS;
 DEFAULT_APPEARANCE[BORDER_RADIUS] = 0;
+DEFAULT_APPEARANCE[HORIZONTAL_PADDING] = 10;
+DEFAULT_APPEARANCE[VERTICAL_PADDING] = 10;
 
 export class Rectangle implements ShapePlugin {
     public identifier(): string {
@@ -36,6 +40,8 @@ export class Rectangle implements ShapePlugin {
     public configurables(factory: ConfigurableFactory) {
         return [
             factory.slider(BORDER_RADIUS, 'Border Radius', 0, 40),
+            factory.number(HORIZONTAL_PADDING, 'Horizontal Padding', 0, 40),
+            factory.number(VERTICAL_PADDING, 'Vertical Padding', 0, 40),
         ];
     }
 
@@ -54,7 +60,9 @@ export class Rectangle implements ShapePlugin {
     }
 
     private createText(ctx: RenderContext) {
-        ctx.renderer2.text(ctx.shape, ctx.rect.deflate(10, 0), p => {
+        const verticalPadding = ctx.shape.getAppearance(VERTICAL_PADDING);
+        const horizontalPadding = ctx.shape.getAppearance(HORIZONTAL_PADDING);
+        ctx.renderer2.text(ctx.shape, ctx.rect.deflate(horizontalPadding, verticalPadding), p => {
             p.setForegroundColor(ctx.shape);
         });
     }


### PR DESCRIPTION
By default, rectangles have padding of 10 pixels. This PR add a configuration option to set this padding.

By default, we have padding of 10:
![image](https://user-images.githubusercontent.com/1090012/161335110-35c9c9d8-5598-43fe-b43d-35ff153ebc41.png)

If you set vertical padding to 0:
![image](https://user-images.githubusercontent.com/1090012/161335160-002f5012-4bf4-44d2-b28f-1e6d6af34a1a.png)
