### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3.1.
+        uses: actions/setup-node@v3.8.1
 
       - name: Install Dependencies
         run: npm i
@@ -26,7 +26,7 @@ jobs:
         run: npm run test:ci
         
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.7
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
         with:
           branch: gh-pages
           folder: dist

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,7 +8,7 @@ jobs:
   
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
     

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3.8.1
 
       - name: Install Dependencies
         run: npm i
@@ -26,7 +26,7 @@ jobs:
         run: npm run test:ci
         
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.8.1](https://github.com/actions/setup-node/releases/tag/v3.8.1)** on 2023-08-17T13:14:07Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.4](https://github.com/codecov/codecov-action/releases/tag/v3.1.4)** on 2023-05-15T20:51:01Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release **[v4.4.3](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.3)** on 2023-07-12T01:51:35Z
