### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
 
       - name: Install Dependencies
         run: npm i
@@ -32,7 +32,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.4.1
+        uses: codecov/codecov-action@v4.5.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
 
       - name: Install Dependencies
         run: npm i
@@ -35,7 +35,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.4.1
+        uses: codecov/codecov-action@v4.5.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.6.1
+        uses: JamesIves/github-pages-deploy-action@v4.6.3
         with:
           branch: gh-pages
           folder: dist


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release **[v4.6.3](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.6.3)** on 2024-07-05T15:32:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.3](https://github.com/actions/setup-node/releases/tag/v4.0.3)** on 2024-07-09T14:22:34Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.5.0](https://github.com/codecov/codecov-action/releases/tag/v4.5.0)** on 2024-06-18T12:09:49Z
