### PR TITLE
VS Code Settings, Apply Slider Value while dragging, Fix vertical scollbar

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,12 @@
         "**/*.gitattributes": true,
         ".vs:": true,
         ".vscode:": true
+    },
+
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     }
 }

--- a/src/wireframes/components/properties/CustomSlider.tsx
+++ b/src/wireframes/components/properties/CustomSlider.tsx
@@ -23,18 +23,11 @@ interface CustomSliderProps {
 }
 
 export const CustomSlider = React.memo(({ max, min, onChange, value }: CustomSliderProps) => {
-    const [sliderValue, setSliderValue] = React.useState<number>(value);
-
-    React.useEffect(() => {
-        setSliderValue(value);
-    }, [value]);
-
     return (
         <Slider
-            value={sliderValue}
+            value={value}
             min={min}
             max={max}
-            onChange={setSliderValue}
-            onAfterChange={onChange} />
+            onChange={onChange} />
     );
 });

--- a/src/wireframes/shapes/neutral/vertical-scrollbar.ts
+++ b/src/wireframes/shapes/neutral/vertical-scrollbar.ts
@@ -42,7 +42,7 @@ export class VerticalScrollbar implements ShapePlugin {
         return [
             factory.color(THUMB_COLOR, 'Thumb Color'),
             factory.slider(THUMB_SIZE, 'Thumb Size', 0, 100),
-            factory.slider(THUMB_SIZE, 'Thumb Position', 0, 100),
+            factory.slider(THUMB_POSITION, 'Thumb Position', 0, 100),
             factory.color(ARROW_COLOR, 'Arrow Color'),
         ];
     }


### PR DESCRIPTION
This PR contains the following

- I explicitely set eslint as VS Code formatter and added an `.editorconfig` to get the formatting consistent with the existing code
- I made the slider apply changes immediately. I like it better this way. What do you think?
- The vertical scrollbar had a bug