### PR TITLE
Fix Rendering

### DIFF
--- a/src/wireframes/shapes/ShapeRenderer.tsx
+++ b/src/wireframes/shapes/ShapeRenderer.tsx
@@ -92,10 +92,7 @@ export const ShapeRenderer = React.memo(React.forwardRef<HTMLDivElement, ShapeRe
                 constraint: plugin?.constraint?.(DefaultConstraintFactory.INSTANCE),
             });
 
-        if (!item.current) {
-            item.current = engine.layer(plugin.identifier()).item(plugin);
-        }
-
+        item.current = engine.layer(plugin.identifier()).item(plugin);
         item.current.plot(shape);
     }, [appearance, engine, plugin, viewBox]);
 


### PR DESCRIPTION
When I typed `t` in the shape palette, an exception was thrown. When the `plugin` changes, `item.current` is not updated, leading to a shape for a wrong plugin being passed to the render item