### PR TITLE
Preparation: Tabs with select Appearance

### DIFF
--- a/src/wireframes/components/properties/CustomProperties.tsx
+++ b/src/wireframes/components/properties/CustomProperties.tsx
@@ -9,6 +9,7 @@ import { Checkbox, Col, InputNumber, Row, Select } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import { Color, ColorPalette, ColorPicker, useEventCallback } from '@app/core';
 import { useAppDispatch } from '@app/store';
+import { Shape } from '@app/wireframes/interface';
 import { changeItemsAppearance, ColorConfigurable, Configurable, getColors, getDiagramId, getSelection, NumberConfigurable, selectColorTab, SelectionConfigurable, SliderConfigurable, TextConfigurable, ToggleConfigurable, useStore } from '@app/wireframes/model';
 import { CustomSlider } from './CustomSlider';
 import { Text } from './Text';
@@ -31,6 +32,8 @@ interface CustomPropertyProps {
 
     // The color tab has changed.
     onColorTabChange: (key: string) => void;
+
+    shape: Shape;
 }
 
 export const CustomProperty = (props: CustomPropertyProps) => {
@@ -41,6 +44,7 @@ export const CustomProperty = (props: CustomPropertyProps) => {
         recentColors,
         selectedColorTab,
         value,
+        shape,
     } = props;
 
     const doChangeValue = useEventCallback((newValue: any) => {
@@ -87,9 +91,10 @@ export const CustomProperty = (props: CustomPropertyProps) => {
 
                 {configurable instanceof SelectionConfigurable &&
                     <Select value={value}
-                        onChange={doChangeValue}
+                        onChange={value => doChangeValue(value === undefined ? null : value)}
+                        allowClear={configurable.config?.allowClear ?? false}
                     >
-                        {configurable.options.map(o =>
+                        {configurable.getOptions(shape).map(o =>
                             <Select.Option key={o} value={o}>{o}</Select.Option>,
                         )}
                     </Select>
@@ -143,6 +148,7 @@ export const CustomProperties = () => {
                     onColorTabChange={doSelectColorTab}
                     recentColors={recentColors}
                     value={selectedShape.appearance.get(c.name)}
+                    shape={selectedShape}
                 />,
             )}
         </>

--- a/src/wireframes/interface/index.ts
+++ b/src/wireframes/interface/index.ts
@@ -170,8 +170,13 @@ export interface ConstraintFactory {
     textSize(paddingX?: number, paddingY?: number, lineHeight?: number, resizeWidth?: false, minWidth?: number): Constraint;
 }
 
+export interface SelectionConfiguration {
+    // if present, the selection can be cleared and null is used as value
+    allowClear?: boolean;
+}
+
 export interface ConfigurableFactory {
-    selection(name: string, label: string, options: string[]): Configurable;
+    selection(name: string, label: string, options: string[] | ((shape: Shape) => string[]), config?: SelectionConfiguration): Configurable;
 
     slider(name: string, label: string, min: number, max: number): Configurable;
 

--- a/src/wireframes/model/configurables.ts
+++ b/src/wireframes/model/configurables.ts
@@ -5,6 +5,8 @@
  * Copyright (c) Sebastian Stehle. All rights reserved.
 */
 
+import { SelectionConfiguration, Shape } from '../interface';
+
 export abstract class Configurable {
     constructor(
         public readonly name: string,
@@ -33,11 +35,16 @@ export class ToggleConfigurable extends Configurable {
 
 export class SelectionConfigurable extends Configurable {
     constructor(name: string, label: string,
-        public readonly options: string[],
+        public readonly options: string[] | ((shape: Shape)=>string[]),
+        public config?: SelectionConfiguration,
     ) {
         super(name, label);
 
         Object.freeze(this);
+    }
+
+    public getOptions(shape: Shape) {
+        return Array.isArray(this.options) ? this.options : this.options(shape);
     }
 }
 

--- a/src/wireframes/model/factories.ts
+++ b/src/wireframes/model/factories.ts
@@ -6,7 +6,7 @@
 */
 
 import { TextMeasurer } from '@app/core';
-import { ConfigurableFactory, ConstraintFactory } from '@app/wireframes/interface';
+import { ConfigurableFactory, ConstraintFactory, SelectionConfiguration, Shape } from '@app/wireframes/interface';
 import { ColorConfigurable, NumberConfigurable, SelectionConfigurable, SliderConfigurable, TextConfigurable, ToggleConfigurable } from './configurables';
 import { Constraint, MinSizeConstraint, SizeConstraint, TextHeightConstraint, TextSizeConstraint } from './constraints';
 
@@ -33,8 +33,8 @@ export class DefaultConstraintFactory implements ConstraintFactory {
 export class DefaultConfigurableFactory implements ConfigurableFactory {
     public static readonly INSTANCE = new DefaultConfigurableFactory();
 
-    public selection(name: string, label: string, options: string[]) {
-        return new SelectionConfigurable(name, label, options);
+    public selection(name: string, label: string, options: string[] | ((shape: Shape)=>string[]), config?: SelectionConfiguration) {
+        return new SelectionConfigurable(name, label, options, config);
     }
 
     public slider(name: string, label: string, min: number, max: number) {

--- a/src/wireframes/renderer/TextAdorner.tsx
+++ b/src/wireframes/renderer/TextAdorner.tsx
@@ -45,6 +45,7 @@ export class TextAdorner extends React.PureComponent<TextAdornerProps> implement
 
     public componentDidMount() {
         window.addEventListener('mousedown', this.handleMouseDown);
+        this.props.engine.subscribe(this);
     }
 
     public componentDidUpdate(prevProps: TextAdornerProps) {


### PR DESCRIPTION
This is a preparation for the Editable Master Pages. I added an appearance to switch the selected tab. The goal is to later allow this property to be overridden in master pages.

The PR also contains a critical bugfix: The `TextAdorner` did not properly subscribe with the engine, making it impossible to edit the texts.